### PR TITLE
docs(features): disambiguation of server connection

### DIFF
--- a/features.md
+++ b/features.md
@@ -17,7 +17,7 @@ title: PgBouncer features
      Transaction pooling
      :  A server connection is assigned to a client only during a
         transaction.  When PgBouncer notices that the transaction is
-        over, the server will be put back into the pool.
+        over, the server connection will be put back into the pool.
 
         This mode breaks a few session-based features of PostgreSQL.
         You can use it only when the application cooperates by not


### PR DESCRIPTION
`server connection` term is consistent with both `Session pooling` section as well as with
https://github.com/pgbouncer/pgbouncer/blob/1f70d2560de0d4390035680e8688f5aecca94e48/doc/usage.md?plain=1#L42-L44