### PR TITLE
fix(docs): update broken EDB link in tutorials section of community page

### DIFF
--- a/community.md
+++ b/community.md
@@ -9,7 +9,7 @@ title: Community
 
   Install on RedHat-based system.
 
-- [How to Setup PgBouncer Connection Pooling with EDB Postgres Standard Server](http://www.enterprisedb.com/resources-community/tutorials-quickstarts/all-platforms/how-setup-pgbouncer-connection-pooling-postg)
+- [How to Set Up PgBouncer for Postgres Plus Standard Server](https://get.enterprisedb.com/docs/Tutorial_All_PPSS_pgBouncer.pdf)
 
   Good overview of PgBouncer concepts.
 


### PR DESCRIPTION
The link to `How to Setup PgBouncer Connection Pooling with EDB Postgres Standard Server` provided in the tutorials section of the community page is broken since the resource has been moved in EDB's side. 
Updated the broken link with a new link which points to the resource.